### PR TITLE
Italic html attributes

### DIFF
--- a/lua/nebulous/config.lua
+++ b/lua/nebulous/config.lua
@@ -13,11 +13,12 @@ end
 
 ---Define default config
 M.config = {
-  st_disable_bg = options("disable_background", false) and "NONE",
-  st_comments  =  options("italic_comments", false)    and "italic" or "NONE",
-  st_keywords  =  options("italic_keywords", false)    and "italic" or "NONE",
-  st_functions =  options("italic_functions", false)   and "italic" or "NONE",
-  st_variables =  options("italic_variables", false)   and "italic" or "NONE",
+  st_disable_bg = options("disable_background", false)           and "NONE",
+  st_comments  =  options("italic_comments", false)              and "italic" or "NONE",
+  st_keywords  =  options("italic_keywords", false)              and "italic" or "NONE",
+  st_functions =  options("italic_functions", false)             and "italic" or "NONE",
+  st_variables =  options("italic_variables", false)             and "italic" or "NONE",
+  st_html_attributes =  options("italic_html_attributes", false) and "italic" or "NONE",
 }
 
 return M

--- a/lua/nebulous/scheme.lua
+++ b/lua/nebulous/scheme.lua
@@ -718,7 +718,7 @@ function setup.load_plugins()
     TSMethod =          { fg = scheme.Aqua,       bg = scheme.none, scheme.none },
     TSStructure =       { fg = scheme.Purple,     bg = scheme.none, scheme.none },
     TSTagDelimiter =    { fg = scheme.Green,      bg = scheme.none, scheme.none },
-    TSTagAttribute =    { fg = scheme.none,       bg = scheme.none, style = "italic"},
+    TSTagAttribute =    { fg = scheme.none,       bg = scheme.none, style = opts.config.st_html_attributes},
     TSNumber =          { fg = scheme.Red,        bg = scheme.none, scheme.none },
     TSFuncMacro =       { fg = scheme.Aqua,       bg = scheme.none, scheme.none },
     TSInclude =         { fg = scheme.Cyan,       bg = scheme.none, scheme.none },

--- a/lua/nebulous/scheme.lua
+++ b/lua/nebulous/scheme.lua
@@ -718,6 +718,7 @@ function setup.load_plugins()
     TSMethod =          { fg = scheme.Aqua,       bg = scheme.none, scheme.none },
     TSStructure =       { fg = scheme.Purple,     bg = scheme.none, scheme.none },
     TSTagDelimiter =    { fg = scheme.Green,      bg = scheme.none, scheme.none },
+    TSTagAttribute =    { fg = scheme.none,       bg = scheme.none, style = "italic"},
     TSNumber =          { fg = scheme.Red,        bg = scheme.none, scheme.none },
     TSFuncMacro =       { fg = scheme.Aqua,       bg = scheme.none, scheme.none },
     TSInclude =         { fg = scheme.Cyan,       bg = scheme.none, scheme.none },


### PR DESCRIPTION
Hace los atributos de html en cursiva, podría ponerse también como una opción de configuración.
![image](https://user-images.githubusercontent.com/29529436/128166847-59510c3d-c948-4465-b38e-00cf70d7eff9.png)